### PR TITLE
Adds organisation to the csr fields (note has to be used with sign-verbatim)

### DIFF
--- a/cmd/cert.go
+++ b/cmd/cert.go
@@ -62,6 +62,10 @@ func init() {
 	certCmd.PersistentFlags().StringSlice(cert.FlagSanHosts, []string{}, "Host Sans. [[]string] (default none)")
 	certCmd.Flag(cert.FlagSanHosts).Shorthand = "s"
 
+	certCmd.PersistentFlags().StringSlice(cert.FlagOrganisation, []string{}, "Organisation(s) - i.e. kubernetes groups. [[]string] (default none)")
+
+	certCmd.Flag(cert.FlagOrganisation).Shorthand = "n"
+
 	certCmd.PersistentFlags().String(cert.FlagOwner, "", "Owner of created file/directories. Uid value also accepted. [string] (default <current user>)")
 	certCmd.Flag(cert.FlagOwner).Shorthand = "o"
 
@@ -109,6 +113,12 @@ func setFlagsCert(c *cert.Cert, cmd *cobra.Command) error {
 		return fmt.Errorf("error parsing %s [[]string] '%s': %v", cert.FlagSanHosts, vSli, err)
 	}
 	c.SetSanHosts(vSli)
+
+	vSli, err = cmd.PersistentFlags().GetStringSlice(cert.FlagOrganisation)
+	if err != nil {
+		return fmt.Errorf("error parsing %s [[]string] '%s' : %v", cert.FlagOrganisation, vSli, err)
+	}
+	c.SetOrganisation(vSli)
 
 	return nil
 }

--- a/pkg/cert/cert.go
+++ b/pkg/cert/cert.go
@@ -40,6 +40,7 @@ type Cert struct {
 
 func (c *Cert) RunCert() error {
 	if err := c.EnsureKey(); err != nil {
+		return fmt.Errorf("error ensuring key: %v", err)
 	}
 
 	//if err := c.TokenRenew(); err != nil {

--- a/pkg/cert/cert.go
+++ b/pkg/cert/cert.go
@@ -18,19 +18,21 @@ const FlagIpSans = "ip-sans"
 const FlagSanHosts = "san-hosts"
 const FlagOwner = "owner"
 const FlagGroup = "group"
+const FlagOrganisation = "organisation"
 
 type Cert struct {
-	role        string
-	commonName  string
-	destination string
-	bitSize     int
-	pemSize     int
-	keyType     string
-	ipSans      []string
-	sanHosts    []string
-	owner       string
-	group       string
-	data        *pem.Block
+	role         string
+	commonName   string
+	organisation []string
+	destination  string
+	bitSize      int
+	pemSize      int
+	keyType      string
+	ipSans       []string
+	sanHosts     []string
+	owner        string
+	group        string
+	data         *pem.Block
 
 	Log           *logrus.Entry
 	instanceToken *instanceToken.InstanceToken
@@ -38,7 +40,6 @@ type Cert struct {
 
 func (c *Cert) RunCert() error {
 	if err := c.EnsureKey(); err != nil {
-		return fmt.Errorf("error ensuring key: %v", err)
 	}
 
 	//if err := c.TokenRenew(); err != nil {
@@ -163,6 +164,14 @@ func (c *Cert) SetCommonName(name string) {
 }
 func (c *Cert) CommonName() string {
 	return c.commonName
+}
+
+func (c *Cert) SetOrganisation(org []string) {
+	c.organisation = org
+}
+
+func (c *Cert) Organisation() []string {
+	return c.organisation
 }
 
 func (c *Cert) SetDestination(destination string) {

--- a/pkg/cert/cert_CSR.go
+++ b/pkg/cert/cert_CSR.go
@@ -147,6 +147,7 @@ func (c *Cert) decodeSec(sec *vault.Secret) (cert string, certCA string, err err
 func (c *Cert) createCSR() (csr []byte, err error) {
 	names := pkix.Name{
 		CommonName: c.CommonName(),
+		Organization: c.Organisation(),
 	}
 	var csrTemplate = x509.CertificateRequest{
 		Subject:            names,


### PR DESCRIPTION
Allows use of vault-helper for leasing certs for RBAC use (e.g. the initial admin with org system:masters and the kubelet with system:nodes)