### PR TITLE
Don't append CA's CN to SAN DNS names

### DIFF
--- a/pkg/kubernetes/pki.go
+++ b/pkg/kubernetes/pki.go
@@ -117,6 +117,7 @@ func (p *PKI) generateCA() error {
 	data := map[string]interface{}{
 		"common_name": description,
 		"ttl":         p.getMaxLeaseTTL(),
+		"exclude_cn_from_sans": true,
 	}
 
 	_, err := p.kubernetes.vaultClient.Logical().Write(path, data)


### PR DESCRIPTION
They fail the golang's CA validation from version 1.10+