### PR TITLE
Merge cert and kubeconfig flags + ensure args are parsed before running

### DIFF
--- a/cmd/cert.go
+++ b/cmd/cert.go
@@ -30,16 +30,7 @@ var certCmd = &cobra.Command{
 		if len(args) != 3 {
 			i.Log.Fatal("wrong number of arguments given. Usage: vault-helper cert [cert role] [common name] [destination path]")
 		}
-		abs, err := filepath.Abs(args[2])
-		if err != nil {
-			i.Log.Fatalf("failed to generate absoute path from destination '%s': %v", args[2], err)
-		}
-		c.SetDestination(abs)
-
-		c.SetRole(args[0])
-		c.SetCommonName(args[1])
-
-		if err := setFlagsCert(c, cmd); err != nil {
+		if err := setFlagsCert(c, cmd, args); err != nil {
 			log.Fatal(err)
 		}
 
@@ -50,34 +41,38 @@ var certCmd = &cobra.Command{
 }
 
 func init() {
-	certCmd.PersistentFlags().Int(cert.FlagKeyBitSize, 2048, "Bit size used for generating key. [int]")
-	certCmd.Flag(cert.FlagKeyBitSize).Shorthand = "b"
-
-	certCmd.PersistentFlags().String(cert.FlagKeyType, "RSA", "Type of key to generate. [string]")
-	certCmd.Flag(cert.FlagKeyType).Shorthand = "t"
-
-	certCmd.PersistentFlags().StringSlice(cert.FlagIpSans, []string{}, "IP sans. [[]string] (default none)")
-	certCmd.Flag(cert.FlagIpSans).Shorthand = "i"
-
-	certCmd.PersistentFlags().StringSlice(cert.FlagSanHosts, []string{}, "Host Sans. [[]string] (default none)")
-	certCmd.Flag(cert.FlagSanHosts).Shorthand = "s"
-
-	certCmd.PersistentFlags().StringSlice(cert.FlagOrganisation, []string{}, "Organisation(s) - i.e. kubernetes groups. [[]string] (default none)")
-
-	certCmd.Flag(cert.FlagOrganisation).Shorthand = "n"
-
-	certCmd.PersistentFlags().String(cert.FlagOwner, "", "Owner of created file/directories. Uid value also accepted. [string] (default <current user>)")
-	certCmd.Flag(cert.FlagOwner).Shorthand = "o"
-
-	certCmd.PersistentFlags().String(cert.FlagGroup, "", "Group of created file/directories. Gid value also accepted. [string] (default <current user-group)")
-	certCmd.Flag(cert.FlagGroup).Shorthand = "g"
-
-	instanceTokenFlags(certCmd)
-
-	RootCmd.AddCommand(certCmd)
+	InitCertCmdFlags(certCmd)
 }
 
-func setFlagsCert(c *cert.Cert, cmd *cobra.Command) error {
+func InitCertCmdFlags(cmd *cobra.Command) {
+	cmd.PersistentFlags().Int(cert.FlagKeyBitSize, 2048, "Bit size used for generating key. [int]")
+	cmd.Flag(cert.FlagKeyBitSize).Shorthand = "b"
+
+	cmd.PersistentFlags().String(cert.FlagKeyType, "RSA", "Type of key to generate. [string]")
+	cmd.Flag(cert.FlagKeyType).Shorthand = "t"
+
+	cmd.PersistentFlags().StringSlice(cert.FlagIpSans, []string{}, "IP sans. [[]string] (default none)")
+	cmd.Flag(cert.FlagIpSans).Shorthand = "i"
+
+	cmd.PersistentFlags().StringSlice(cert.FlagSanHosts, []string{}, "Host Sans. [[]string] (default none)")
+	cmd.Flag(cert.FlagSanHosts).Shorthand = "s"
+
+	cmd.PersistentFlags().StringSlice(cert.FlagOrganisation, []string{}, "Organisation(s) - i.e. kubernetes groups. [[]string] (default none)")
+
+	cmd.Flag(cert.FlagOrganisation).Shorthand = "n"
+
+	cmd.PersistentFlags().String(cert.FlagOwner, "", "Owner of created file/directories. Uid value also accepted. [string] (default <current user>)")
+	cmd.Flag(cert.FlagOwner).Shorthand = "o"
+
+	cmd.PersistentFlags().String(cert.FlagGroup, "", "Group of created file/directories. Gid value also accepted. [string] (default <current user-group)")
+	cmd.Flag(cert.FlagGroup).Shorthand = "g"
+
+	instanceTokenFlags(cmd)
+
+	RootCmd.AddCommand(cmd)
+}
+
+func setFlagsCert(c *cert.Cert, cmd *cobra.Command, args []string) error {
 	vInt, err := cmd.PersistentFlags().GetInt(cert.FlagKeyBitSize)
 	if err != nil {
 		return fmt.Errorf("error parsing %s [int] '%d': %v", cert.FlagKeyBitSize, vInt, err)
@@ -119,6 +114,15 @@ func setFlagsCert(c *cert.Cert, cmd *cobra.Command) error {
 		return fmt.Errorf("error parsing %s [[]string] '%s' : %v", cert.FlagOrganisation, vSli, err)
 	}
 	c.SetOrganisation(vSli)
+
+	abs, err := filepath.Abs(args[2])
+	if err != nil {
+		return fmt.Errorf("failed to generate absoute path from destination '%s': %v", args[2], err)
+	}
+	c.SetDestination(abs)
+
+	c.SetRole(args[0])
+	c.SetCommonName(args[1])
 
 	return nil
 }

--- a/cmd/kubeconfig.go
+++ b/cmd/kubeconfig.go
@@ -11,8 +11,7 @@ import (
 
 // initCmd represents the init command
 var kubeconfCmd = &cobra.Command{
-	Use: "kubeconfig [cert role] [common name] [cert path] [kubeconfig path]",
-	// TODO: Make short better
+	Use:   "kubeconfig [cert role] [common name] [cert path] [kubeconfig path]",
 	Short: "Create local key to generate a CSR. Call vault with CSR for specified cert role. Write kubeconfig to yaml file.",
 	Run: func(cmd *cobra.Command, args []string) {
 		log := LogLevel(cmd)
@@ -21,27 +20,30 @@ var kubeconfCmd = &cobra.Command{
 			log.Fatal("Wrong number of arguments given.\nUsage: vault-helper kubeconfig [cert role] [common name] [cert path] [kubeconfig path]")
 		}
 
-		abs, err := filepath.Abs(args[3])
-		if err != nil {
-			log.Fatalf("error generating absoute path from destination '%s': %v", args[3], err)
-		}
-		args = args[:3]
-
 		i, err := newInstanceToken(cmd)
 		if err != nil {
 			i.Log.Fatal(err)
 		}
-
 		if err := i.TokenRenewRun(); err != nil {
 			i.Log.Fatal(err)
 		}
+
 		c := cert.New(i.Log, i)
-		if err := c.RunCert(); err != nil {
+		if err := setFlagsCert(c, cmd, args); err != nil {
 			c.Log.Fatal(err)
 		}
 
+		abs, err := filepath.Abs(args[3])
+		if err != nil {
+			log.Fatalf("error generating absolute path from destination '%s': %v", args[3], err)
+		}
+
 		u := kubeconfig.New(log, c)
-		u.SetFilePath(abs)
+		u.SetKubeConfigPath(abs)
+
+		if err := c.RunCert(); err != nil {
+			c.Log.Fatal(err)
+		}
 
 		if err := u.RunKube(); err != nil {
 			u.Log.Fatal(err)
@@ -50,25 +52,5 @@ var kubeconfCmd = &cobra.Command{
 }
 
 func init() {
-	kubeconfCmd.PersistentFlags().Int(cert.FlagKeyBitSize, 2048, "Bit size used for generating key. [int]")
-	kubeconfCmd.Flag(cert.FlagKeyBitSize).Shorthand = "b"
-
-	kubeconfCmd.PersistentFlags().String(cert.FlagKeyType, "RSA", "Type of key to generate. [string]")
-	kubeconfCmd.Flag(cert.FlagKeyType).Shorthand = "t"
-
-	kubeconfCmd.PersistentFlags().StringSlice(cert.FlagIpSans, []string{}, "IP sans. [[]string] (default none)")
-	kubeconfCmd.Flag(cert.FlagIpSans).Shorthand = "i"
-
-	kubeconfCmd.PersistentFlags().StringSlice(cert.FlagSanHosts, []string{}, "Host Sans. [[]string] (default none)")
-	kubeconfCmd.Flag(cert.FlagSanHosts).Shorthand = "s"
-
-	kubeconfCmd.PersistentFlags().String(cert.FlagOwner, "", "Owner of created file/directories. Uid value also accepted. [string (default <current user>)")
-	kubeconfCmd.Flag(cert.FlagOwner).Shorthand = "o"
-
-	kubeconfCmd.PersistentFlags().String(cert.FlagGroup, "", "Group of created file/directories. Gid value also accepted. [string] (default <current user-group>)")
-	kubeconfCmd.Flag(cert.FlagGroup).Shorthand = "g"
-
-	instanceTokenFlags(kubeconfCmd)
-
-	RootCmd.AddCommand(kubeconfCmd)
+	InitCertCmdFlags(kubeconfCmd)
 }

--- a/pkg/cert/cert.go
+++ b/pkg/cert/cert.go
@@ -43,22 +43,12 @@ func (c *Cert) RunCert() error {
 		return fmt.Errorf("error ensuring key: %v", err)
 	}
 
-	//if err := c.TokenRenew(); err != nil {
-	//	return fmt.Errorf("error renewing tokens: %v", err)
-	//}
-
 	if err := c.RequestCertificate(); err != nil {
 		return fmt.Errorf("error requesting certificate: %v", err)
 	}
 
 	return nil
 }
-
-//func (c *Cert) TokenRenew() error {
-//	i := instanceToken.New(c.vaultClient, c.Log)
-//
-//	return i.TokenRenewRun()
-//}
 
 func (c *Cert) DeleteFile(path string) error {
 	if err := os.Remove(path); err != nil {

--- a/pkg/kubeconfig/kubeconfig.go
+++ b/pkg/kubeconfig/kubeconfig.go
@@ -2,14 +2,15 @@ package kubeconfig
 
 import (
 	"github.com/jetstack/vault-helper/pkg/cert"
+
 	"github.com/sirupsen/logrus"
 )
 
 type Kubeconfig struct {
-	filePath  string
-	certKey64 string
-	certCA64  string
-	cert64    string
+	configPath string
+	certKey64  string
+	certCA64   string
+	cert64     string
 
 	cert *cert.Cert
 	Log  *logrus.Entry
@@ -40,18 +41,18 @@ func (u *Kubeconfig) RunKube() error {
 	return u.StoreYaml(yml)
 }
 
+func (u *Kubeconfig) ConfigPath() string {
+	return u.configPath
+}
+func (u *Kubeconfig) SetKubeConfigPath(path string) {
+	u.configPath = path
+}
+
 func (u *Kubeconfig) SetCert(cert *cert.Cert) {
 	u.cert = cert
 }
 func (u *Kubeconfig) Cert() (c *cert.Cert) {
 	return u.cert
-}
-
-func (u *Kubeconfig) SetFilePath(path string) {
-	u.filePath = path
-}
-func (u *Kubeconfig) FilePath() (path string) {
-	return u.filePath
 }
 
 func (u *Kubeconfig) SetCertCA64(byt string) {

--- a/pkg/kubeconfig/kubeconfig_test.go
+++ b/pkg/kubeconfig/kubeconfig_test.go
@@ -58,7 +58,7 @@ func TestKubeconf_Busy_Vault(t *testing.T) {
 		t.Fatalf("error runinning kubeconfig: %v", err)
 	}
 
-	yml := importYaml(t, u.FilePath())
+	yml := importYaml(t, u.ConfigPath())
 
 	ymlKeyBef := yml.Users[0].User.ClientKeyData
 	ymlCerBef := yml.Users[0].User.ClientCertificateData
@@ -71,7 +71,7 @@ func TestKubeconf_Busy_Vault(t *testing.T) {
 		t.Fatalf("Expected 400 error, premisson denied")
 	}
 
-	yml = importYaml(t, u.FilePath())
+	yml = importYaml(t, u.ConfigPath())
 
 	ymlKeyAft := yml.Users[0].User.ClientKeyData
 	ymlCerAft := yml.Users[0].User.ClientCertificateData
@@ -109,7 +109,7 @@ func TestKubeconf_File_Perms(t *testing.T) {
 		t.Fatalf("error runinning kubeconfig: %v", err)
 	}
 
-	yaml := filepath.Clean(u.FilePath())
+	yaml := filepath.Clean(u.ConfigPath())
 	checkFilePerm(t, yaml, os.FileMode(0600))
 	checkOwnerGroup(t, yaml)
 }
@@ -149,7 +149,7 @@ func TestKubeconf_Cert_Data(t *testing.T) {
 		t.Fatalf("failed to encode data at file '%s': %v", cerPem, err)
 	}
 
-	yml := importYaml(t, u.FilePath())
+	yml := importYaml(t, u.ConfigPath())
 
 	ymlKey := yml.Users[0].User.ClientKeyData
 	ymlCer := yml.Users[0].User.ClientCertificateData
@@ -297,7 +297,7 @@ func initKubeconf(t *testing.T, cert *cert.Cert) (u *Kubeconfig) {
 	log := logrus.NewEntry(logger)
 
 	u = New(log, cert)
-	u.SetFilePath(cert.Destination())
+	u.SetKubeConfigPath(cert.Destination())
 
 	return u
 }

--- a/pkg/kubeconfig/kubeconfig_yaml.go
+++ b/pkg/kubeconfig/kubeconfig_yaml.go
@@ -73,7 +73,7 @@ func (u *Kubeconfig) EncodeCerts() error {
 }
 
 func (u *Kubeconfig) StoreYaml(yml string) error {
-	path := filepath.Clean(u.FilePath())
+	path := filepath.Clean(u.ConfigPath())
 
 	file, err := os.Create(path)
 	if err != nil {
@@ -91,7 +91,7 @@ func (u *Kubeconfig) StoreYaml(yml string) error {
 }
 
 func (u *Kubeconfig) WritePermissions() error {
-	return u.Cert().WritePermissions(u.FilePath(), os.FileMode(0600))
+	return u.Cert().WritePermissions(u.ConfigPath(), os.FileMode(0600))
 }
 
 func (u *Kubeconfig) BuildYaml() (yml string, err error) {


### PR DESCRIPTION
kubeconfig was not parsing all args + flags before running. This ensures they do.

Kubconfig and cert flags have now been merged into cmd/cert.go

```release-note
Fix `kubeconfig` sub command, which did not parse all flags
```
fixes #10 