### PR TITLE
Enable client flag on kube-apiserver cert

### DIFF
--- a/pkg/kubernetes/kubernetes_pki_roles.go
+++ b/pkg/kubernetes/kubernetes_pki_roles.go
@@ -92,7 +92,7 @@ func (k *Kubernetes) k8sAPIServerRole() *pkiRole {
 			"allow_bare_domains":  true,
 			"allow_ip_sans":       true,
 			"server_flag":         true,
-			"client_flag":         false,
+			"client_flag":         true,
 			"max_ttl":             fmt.Sprintf("%ds", int(k.MaxValidityComponents.Seconds())),
 			"ttl":                 fmt.Sprintf("%ds", int(k.MaxValidityComponents.Seconds())),
 		},


### PR DESCRIPTION
```release-note
Enable client flag on kube-apiserver cert. This allows the cert to be used to authorize the kube-apiserver on kubelets.
```