### PR TITLE
Adds "*.ec2.internal" common_name for kubelet role

### DIFF
--- a/pkg/kubernetes/kubernetes_pki_roles.go
+++ b/pkg/kubernetes/kubernetes_pki_roles.go
@@ -127,7 +127,7 @@ func (k *Kubernetes) k8sKubeletRole() *pkiRole {
 			"use_csr_sans":        false,
 			"enforce_hostnames":   false,
 			"organization":        "system:nodes",
-			"allowed_domains":     strings.Join([]string{"kubelet", "system:node", "system:node:*", "*.compute.internal"}, ","),
+			"allowed_domains":     strings.Join([]string{"kubelet", "system:node", "system:node:*", "*.compute.internal", "*.ec2.internal"}, ","),
 			"allow_bare_domains":  true,
 			"allow_glob_domains":  true,
 			"allow_any_name":      false,


### PR DESCRIPTION
Adds *.ec2.internal common_name option to kubelet role for us-east-1 region.

Fixes #17 

/assign @simonswine 

```release-note
"*ec2.internal" wild card common_name option added to kubelet PKI role
```