### PR TITLE
Write the encryption config to vault

### DIFF
--- a/pkg/kubernetes/generic.go
+++ b/pkg/kubernetes/generic.go
@@ -53,7 +53,7 @@ func (g *Generic) Ensure() error {
 	}
 
 	//TODO the same code is ran when generating the secrets mount
-	rsaKeyPath := g.rsaPath()
+	rsaKeyPath := g.ServiceAccountsPath()
 	if secret, err := g.kubernetes.vaultClient.Logical().Read(rsaKeyPath); err != nil {
 		return fmt.Errorf("error checking for secret %s: %v", rsaKeyPath, err)
 	} else if secret == nil {
@@ -85,8 +85,8 @@ func (g *Generic) EnsureDryRun() (bool, error) {
 		return true, nil
 	}
 
-	if secret, err := g.kubernetes.vaultClient.Logical().Read(g.rsaPath()); err != nil {
-		return false, fmt.Errorf("error checking for secret %s: %v", g.rsaPath(), err)
+	if secret, err := g.kubernetes.vaultClient.Logical().Read(g.ServiceAccountsPath()); err != nil {
+		return false, fmt.Errorf("error checking for secret %s: %v", g.ServiceAccountsPath(), err)
 	} else if secret == nil {
 		return true, nil
 	}
@@ -103,7 +103,7 @@ func (g *Generic) EnsureDryRun() (bool, error) {
 func (g *Generic) Delete() error {
 	var result *multierror.Error
 
-	if err := g.deleteSecret(g.rsaPath()); err != nil {
+	if err := g.deleteSecret(g.ServiceAccountsPath()); err != nil {
 		result = multierror.Append(result, err)
 	}
 
@@ -145,7 +145,7 @@ func (g *Generic) GenerateSecretsMount() error {
 		g.Log.Infof("Mounted secrets: '%s'", g.Path())
 	}
 
-	rsaKeyPath := g.rsaPath()
+	rsaKeyPath := g.ServiceAccountsPath()
 	if secret, err := g.kubernetes.vaultClient.Logical().Read(rsaKeyPath); err != nil {
 		return fmt.Errorf("error checking for secret %s: %v", rsaKeyPath, err)
 	} else if secret == nil {
@@ -375,7 +375,8 @@ func (g *Generic) Name() string {
 	return "secrets"
 }
 
-func (g *Generic) rsaPath() string {
+// ServiceAccountsPath is the vault path for the service-accounts certificate content
+func (g *Generic) ServiceAccountsPath() string {
 	return filepath.Join(g.Path(), "service-accounts")
 }
 

--- a/pkg/kubernetes/generic.go
+++ b/pkg/kubernetes/generic.go
@@ -7,9 +7,11 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
+	"encoding/base64"
 	"encoding/pem"
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/hashicorp/go-multierror"
 	vault "github.com/hashicorp/vault/api"
@@ -79,6 +81,12 @@ func (g *Generic) EnsureDryRun() (bool, error) {
 		return true, nil
 	}
 
+	if secret, err := g.kubernetes.vaultClient.Logical().Read(g.EncryptionConfigPath()); err != nil {
+		return false, fmt.Errorf("error checking for secret %s: %v", g.EncryptionConfigPath(), err)
+	} else if secret == nil {
+		return true, nil
+	}
+
 	return false, nil
 }
 
@@ -98,6 +106,51 @@ func (g *Generic) Delete() error {
 
 func (g *Generic) Path() string {
 	return filepath.Join(g.kubernetes.Path(), "secrets")
+}
+
+func (g *Generic) GenerateSecretsMount() error {
+	mount, err := GetMountByPath(g.kubernetes.vaultClient, g.Path())
+	if err != nil {
+		return err
+	}
+
+	if mount == nil {
+		g.Log.Debugf("No secrects mount found for: %s", g.Path())
+		err = g.kubernetes.vaultClient.Sys().Mount(
+			g.Path(),
+			&vault.MountInput{
+				Description: "Kubernetes " + g.kubernetes.clusterID + " secrets",
+				Type:        genericType,
+			},
+		)
+
+		if err != nil {
+			return fmt.Errorf("error creating mount: %v", err)
+		}
+
+		g.Log.Infof("Mounted secrets: '%s'", g.Path())
+	}
+
+	rsaKeyPath := g.rsaPath()
+	if secret, err := g.kubernetes.vaultClient.Logical().Read(rsaKeyPath); err != nil {
+		return fmt.Errorf("error checking for secret %s: %v", rsaKeyPath, err)
+	} else if secret == nil {
+		err = g.writeNewRSAKey(rsaKeyPath, 4096)
+		if err != nil {
+			return fmt.Errorf("error creating rsa key at %s: %v", rsaKeyPath, err)
+		}
+	}
+
+	if secret, err := g.kubernetes.vaultClient.Logical().Read(g.EncryptionConfigPath()); err != nil {
+		return fmt.Errorf("error checking for secret %s: %v", g.EncryptionConfigPath(), err)
+	} else if secret == nil {
+		err = g.writeNewEncryptionConfig(g.EncryptionConfigPath())
+		if err != nil {
+			return fmt.Errorf("error creating encryption config at %s: %v", g.EncryptionConfigPath(), err)
+		}
+	}
+
+	return nil
 }
 
 func (g *Generic) unMount() error {
@@ -137,6 +190,41 @@ func (g *Generic) writeNewRSAKey(secretPath string, bitSize int) error {
 	_, err = g.kubernetes.vaultClient.Logical().Write(secretPath, writeData)
 	if err != nil {
 		return fmt.Errorf("error writting key to secrets: %v", err)
+	}
+
+	g.Log.Infof("Key written to secrets '%s'", secretPath)
+
+	return nil
+}
+
+func (g *Generic) writeNewEncryptionConfig(secretPath string) error {
+	encryptionConfig := `kind: EncryptionConfig
+apiVersion: v1
+resources:
+  - resources:
+    - secrets
+    providers:
+    - aescbc:
+        keys:
+        - name: key1
+          secret: SECRET
+    - identity: {}
+`
+
+	secret := make([]byte, 32)
+
+	_, err := rand.Read(secret)
+	if err != nil {
+		return fmt.Errorf("error generating secret: %v", err)
+	}
+
+	writeData := map[string]interface{}{
+		"content": strings.Replace(encryptionConfig, "SECRET", base64.StdEncoding.EncodeToString(secret), 1),
+	}
+
+	_, err = g.kubernetes.vaultClient.Logical().Write(secretPath, writeData)
+	if err != nil {
+		return fmt.Errorf("error writing key to secrets: %v", err)
 	}
 
 	g.Log.Infof("Key written to secrets '%s'", secretPath)
@@ -275,4 +363,9 @@ func (g *Generic) Name() string {
 
 func (g *Generic) rsaPath() string {
 	return filepath.Join(g.Path(), "service-accounts")
+}
+
+// EncryptionConfigPath is the vault path for the kubernetes encryption config file content
+func (g *Generic) EncryptionConfigPath() string {
+	return filepath.Join(g.Path(), "encryption-config")
 }

--- a/pkg/kubernetes/kubernetes_policies.go
+++ b/pkg/kubernetes/kubernetes_policies.go
@@ -116,7 +116,7 @@ func (k *Kubernetes) masterPolicy() *Policy {
 				capabilities: []string{"create", "read", "update"},
 			},
 			&policyPath{
-				path:         filepath.Join(k.secretsGeneric.Path(), "service-accounts"),
+				path:         k.secretsGeneric.ServiceAccountsPath(),
 				capabilities: []string{"read"},
 			},
 			&policyPath{

--- a/pkg/kubernetes/kubernetes_policies.go
+++ b/pkg/kubernetes/kubernetes_policies.go
@@ -119,6 +119,10 @@ func (k *Kubernetes) masterPolicy() *Policy {
 				path:         filepath.Join(k.secretsGeneric.Path(), "service-accounts"),
 				capabilities: []string{"read"},
 			},
+			&policyPath{
+				path:         k.secretsGeneric.EncryptionConfigPath(),
+				capabilities: []string{"read"},
+			},
 		},
 	}
 


### PR DESCRIPTION
Similar to the behavior for the service-account key, this will
additionally write an EncryptionConfig file with a secret to vault when
planning/applying.

A new config file will only be written when one does not already exist.

**Release note**:
```release-note
Write k8s etcd encryption config as vault secret
```