### PR TITLE
Migrate docker_* build targets to use docker cp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,8 @@
 # Copyright Jetstack Ltd. See LICENSE for details.
+PACKAGE_NAME ?= github.com/jetstack/vault-helper
+CONTAINER_DIR := /go/src/$(PACKAGE_NAME)
+GO_VERSION := 1.10.1
+
 BINDIR ?= $(PWD)/bin
 PATH   := $(BINDIR):$(PATH)
 
@@ -8,8 +12,6 @@ REGISTRY := quay.io/jetstack
 IMAGE_NAME := vault-helper
 IMAGE_TAGS := canary
 BUILD_TAG := build
-
-BUILD_IMAGE_NAME := golang:1.9.2
 
 CI_COMMIT_TAG ?= $(shell git rev-parse HEAD)
 CI_COMMIT_SHA ?= unknown
@@ -71,7 +73,7 @@ bin/mockgen:
 	go build -o $(BINDIR)/mockgen ./vendor/github.com/golang/mock/mockgen
 
 bin/vault:
-	which unzip || apt-get install -y unzip
+	which unzip || ( apt-get update && apt-get -y install unzip)
 	mkdir -p $(BINDIR)
 	curl -sL  https://releases.hashicorp.com/vault/$(VAULT_VERSION)/vault_$(VAULT_VERSION)_linux_amd64.zip > $(BINDIR)/vault.zip
 	echo "$(VAULT_HASH)  $(BINDIR)/vault.zip" | sha256sum  -c
@@ -84,25 +86,30 @@ go_generate: depend
 	$(BINDIR)/mockgen -package kubernetes -source=pkg/kubernetes/kubernetes.go > pkg/kubernetes/kubernetes_mocks_test.go
 	sed -i '1s/^/\/\/ Copyright Jetstack Ltd. See LICENSE for details.\n/' pkg/kubernetes/kubernetes_mocks_test.go
 
-.builder_image:
-	docker pull ${BUILD_IMAGE_NAME}
-
-
 # Builder image targets
 #######################
-docker_%: .builder_image
-	docker run -it \
-		-v ${GOPATH}/src:/go/src \
-		-v $(shell pwd):/go/src/${GO_PKG} \
-		-w /go/src/${GO_PKG} \
-		-e GOPATH=/go \
-		${BUILD_IMAGE_NAME} \
-		/bin/sh -c "make $*"
+docker_%:
+	# create a container
+	$(eval CONTAINER_ID := $(shell docker create \
+		-i \
+		-w $(CONTAINER_DIR) \
+		golang:${GO_VERSION} \
+		/bin/bash -c "make $*" \
+	))
 
-# Docker targets
-################
-docker_build:
-	docker build -t $(REGISTRY)/$(IMAGE_NAME):$(BUILD_TAG) .
+	# copy stuff into container
+	(git ls-files && git ls-files --others --exclude-standard) | tar cf -  -T - | docker cp - $(CONTAINER_ID):$(CONTAINER_DIR)
+
+	# run build inside container
+	docker start -a -i $(CONTAINER_ID)
+
+	# copy artifacts over
+	if [ "$*" = "build" ]; then \
+		docker cp $(CONTAINER_ID):$(CONTAINER_DIR)/vault-helper_linux_amd64 vault-helper_linux_amd64; \
+	fi
+
+	# remove container
+	docker rm $(CONTAINER_ID)
 
 docker_push: docker_build
 	set -e; \


### PR DESCRIPTION
- Remove duplicated image <-> docker_image task
- Upgrade golang to 1.10.1 (align with gitlab ci's version)

```release-notes
Fix vault-helper's container build targets (`docker_*`)
```