### PR TITLE
Fix typo in log/error output

### DIFF
--- a/pkg/kubernetes/generic_vault_backend.go
+++ b/pkg/kubernetes/generic_vault_backend.go
@@ -32,7 +32,7 @@ func (g *GenericVaultBackend) Ensure() error {
 	}
 
 	if mount == nil {
-		g.Log.Debugf("No secrects mount found for: %s", g.Path())
+		g.Log.Debugf("No secrets mount found for: %s", g.Path())
 		err = g.kubernetes.vaultClient.Sys().Mount(
 			g.Path(),
 			&vault.MountInput{
@@ -119,7 +119,7 @@ func (g *GenericVaultBackend) Path() string {
 
 func (g *GenericVaultBackend) unMount() error {
 	if err := g.kubernetes.vaultClient.Sys().Unmount(g.Path()); err != nil {
-		return fmt.Errorf("failed to unmount secrects mount: %v", err)
+		return fmt.Errorf("failed to unmount secrets mount: %v", err)
 	}
 
 	return nil


### PR DESCRIPTION
Spotted while running tarmak (vault-helper used as dependency)

```release-note
NONE
```