### PR TITLE
Ensure init tokens have high ttl (5 years)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ generate: go_generate
 go_verify: go_fmt go_vet verify_boilerplate go_test
 
 go_test:
-	go test $$(go list ./pkg/... ./cmd/...)
+	go test --count=1 $$(go list ./pkg/... ./cmd/...)
 
 go_fmt:
 	@set -e; \

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PACKAGE_NAME ?= github.com/jetstack/vault-helper
 CONTAINER_DIR := /go/src/$(PACKAGE_NAME)
 GO_VERSION := 1.11.4
 
-BINDIR ?= $(PWD)/bin
+BINDIR ?= $(CURDIR)/bin
 PATH   := $(BINDIR):$(PATH)
 
 HACK_DIR     ?= hack

--- a/cmd/dev_server.go
+++ b/cmd/dev_server.go
@@ -48,7 +48,7 @@ var devServerCmd = &cobra.Command{
 
 		v := dev_server.New(log)
 		v.Vault.SetPort(port)
-		if err := v.Vault.Start("../bin/vault"); err != nil {
+		if err := v.Vault.Start("vault"); err != nil {
 			Must(fmt.Errorf("unable to initialise dev vault: %s", err))
 		}
 

--- a/cmd/dev_server.go
+++ b/cmd/dev_server.go
@@ -48,7 +48,7 @@ var devServerCmd = &cobra.Command{
 
 		v := dev_server.New(log)
 		v.Vault.SetPort(port)
-		if err := v.Vault.Start(); err != nil {
+		if err := v.Vault.Start("../bin/vault"); err != nil {
 			Must(fmt.Errorf("unable to initialise dev vault: %s", err))
 		}
 

--- a/pkg/cert/cert_test.go
+++ b/pkg/cert/cert_test.go
@@ -431,7 +431,7 @@ func initKubernetes(vaultDev *vault_dev.VaultDev) *kubernetes.Kubernetes {
 func initVaultDev() *vault_dev.VaultDev {
 	vaultDev := vault_dev.New()
 
-	if err := vaultDev.Start(); err != nil {
+	if err := vaultDev.Start("../../bin/vault"); err != nil {
 		logrus.Fatalf("unable to initialise vault dev server for integration tests: %v", err)
 	}
 

--- a/pkg/cert/cert_test.go
+++ b/pkg/cert/cert_test.go
@@ -23,7 +23,13 @@ var vaultDev *vault_dev.VaultDev
 var tempDirs []string
 
 func TestMain(m *testing.M) {
-	vaultDev = initVaultDev()
+	var err error
+
+	vaultDev, err = initVaultDev()
+	if err != nil {
+		logrus.Fatal(err)
+	}
+
 	initKubernetes(vaultDev)
 
 	// this runs all tests
@@ -428,14 +434,19 @@ func initKubernetes(vaultDev *vault_dev.VaultDev) *kubernetes.Kubernetes {
 }
 
 // Start vault_dev for testing
-func initVaultDev() *vault_dev.VaultDev {
+func initVaultDev() (*vault_dev.VaultDev, error) {
 	vaultDev := vault_dev.New()
 
-	if err := vaultDev.Start("../../bin/vault"); err != nil {
-		logrus.Fatalf("unable to initialise vault dev server for integration tests: %v", err)
+	binPath, err := filepath.Abs("../../bin/vault")
+	if err != nil {
+		return nil, err
 	}
 
-	return vaultDev
+	if err := vaultDev.Start(binPath); err != nil {
+		return nil, fmt.Errorf("unable to initialise vault dev server for integration tests: %v", err)
+	}
+
+	return vaultDev, nil
 }
 
 // Init instance token for testing

--- a/pkg/instanceToken/renew_token_test.go
+++ b/pkg/instanceToken/renew_token_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strconv"
 	"testing"
 
@@ -21,7 +22,12 @@ var vaultDev *vault_dev.VaultDev
 var tempDirs []string
 
 func TestMain(m *testing.M) {
-	vaultDev = initVaultDev()
+	var err error
+
+	vaultDev, err = initVaultDev()
+	if err != nil {
+		logrus.Fatal(err)
+	}
 
 	// this runs all tests
 	returnCode := m.Run()
@@ -260,12 +266,17 @@ func initKubernetes(t *testing.T, vaultDev *vault_dev.VaultDev) *kubernetes.Kube
 }
 
 // Start vault_dev for testing
-func initVaultDev() *vault_dev.VaultDev {
+func initVaultDev() (*vault_dev.VaultDev, error) {
 	vaultDev := vault_dev.New()
 
-	if err := vaultDev.Start("../../bin/vault"); err != nil {
-		logrus.Fatalf("unable to initialise vault dev server for integration tests: %v", err)
+	binPath, err := filepath.Abs("../../bin/vault")
+	if err != nil {
+		return nil, err
 	}
 
-	return vaultDev
+	if err := vaultDev.Start(binPath); err != nil {
+		return nil, fmt.Errorf("unable to initialise vault dev server for integration tests: %v", err)
+	}
+
+	return vaultDev, nil
 }

--- a/pkg/instanceToken/renew_token_test.go
+++ b/pkg/instanceToken/renew_token_test.go
@@ -263,7 +263,7 @@ func initKubernetes(t *testing.T, vaultDev *vault_dev.VaultDev) *kubernetes.Kube
 func initVaultDev() *vault_dev.VaultDev {
 	vaultDev := vault_dev.New()
 
-	if err := vaultDev.Start(); err != nil {
+	if err := vaultDev.Start("../../bin/vault"); err != nil {
 		logrus.Fatalf("unable to initialise vault dev server for integration tests: %v", err)
 	}
 

--- a/pkg/kubeconfig/kubeconfig_test.go
+++ b/pkg/kubeconfig/kubeconfig_test.go
@@ -254,7 +254,7 @@ func initKubernetes(t *testing.T, vaultDev *vault_dev.VaultDev) *kubernetes.Kube
 func initVaultDev() *vault_dev.VaultDev {
 	vaultDev := vault_dev.New()
 
-	if err := vaultDev.Start(); err != nil {
+	if err := vaultDev.Start("../../bin/vault"); err != nil {
 		logrus.Fatalf("unable to initialise vault dev server for integration tests: %v", err)
 	}
 

--- a/pkg/kubeconfig/kubeconfig_test.go
+++ b/pkg/kubeconfig/kubeconfig_test.go
@@ -25,7 +25,12 @@ var vaultDev *vault_dev.VaultDev
 var tempDirs []string
 
 func TestMain(m *testing.M) {
-	vaultDev = initVaultDev()
+	var err error
+
+	vaultDev, err = initVaultDev()
+	if err != nil {
+		logrus.Fatal(err)
+	}
 
 	// this runs all tests
 	returnCode := m.Run()
@@ -251,14 +256,19 @@ func initKubernetes(t *testing.T, vaultDev *vault_dev.VaultDev) *kubernetes.Kube
 }
 
 // Start vault_dev for testing
-func initVaultDev() *vault_dev.VaultDev {
+func initVaultDev() (*vault_dev.VaultDev, error) {
 	vaultDev := vault_dev.New()
 
-	if err := vaultDev.Start("../../bin/vault"); err != nil {
-		logrus.Fatalf("unable to initialise vault dev server for integration tests: %v", err)
+	binPath, err := filepath.Abs("../../bin/vault")
+	if err != nil {
+		return nil, err
 	}
 
-	return vaultDev
+	if err := vaultDev.Start(binPath); err != nil {
+		return nil, fmt.Errorf("unable to initialise vault dev server for integration tests: %v", err)
+	}
+
+	return vaultDev, nil
 }
 
 // Init Cert for tesing

--- a/pkg/kubernetes/init_token.go
+++ b/pkg/kubernetes/init_token.go
@@ -4,6 +4,7 @@ package kubernetes
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/hashicorp/go-multierror"
 	vault "github.com/hashicorp/vault/api"
@@ -19,6 +20,10 @@ type InitToken struct {
 
 func (i *InitToken) Ensure() error {
 	var result error
+
+	if err := i.ensureCreated(); err != nil {
+		return err
+	}
 
 	// always ensure token role and init token policy is set (this is idempotent)
 	if err := i.writeTokenRole(); err != nil {
@@ -38,7 +43,45 @@ func (i *InitToken) Ensure() error {
 	}
 	i.token = &initToken
 
-	return result
+	// Renew token
+	_, err = i.kubernetes.vaultClient.Auth().Token().Renew(initToken, 0)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (i *InitToken) ensureCreated() error {
+	token, err := i.InitToken()
+	if err != nil {
+		return err
+	}
+
+	_, err = i.kubernetes.vaultClient.Auth().Token().Lookup(token)
+	if err == nil {
+		return nil
+	}
+
+	if !strings.Contains(err.Error(), "Code: 403.") ||
+		!strings.Contains(err.Error(), "bad token") {
+		i.kubernetes.Log.Errorf("GOT ERROR HERE!\n%s\n", err)
+		return err
+	}
+
+	// token revoked or expired
+	_, err = i.kubernetes.vaultClient.Auth().Token().CreateOrphan(&vault.TokenCreateRequest{
+		ID:          token,
+		DisplayName: fmt.Sprintf("%s/secrets/init_token_%s", i.kubernetes.Path(), i.Role),
+		TTL:         fmt.Sprintf("%d", int(i.kubernetes.MaxValidityInitTokens.Seconds())),
+		Period:      fmt.Sprintf("%d", int(i.kubernetes.MaxValidityInitTokens.Seconds())),
+		Policies:    []string{"default", fmt.Sprintf("%s-creator", i.namePath())},
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (i *InitToken) Delete() error {
@@ -57,6 +100,11 @@ func (i *InitToken) Delete() error {
 
 func (i *InitToken) EnsureDryRun() (bool, error) {
 	var result *multierror.Error
+
+	inDate, err := i.ensureDryRunInDate()
+	if err != nil || !inDate {
+		return inDate, err
+	}
 
 	secret, err := i.readTokenRole()
 	if err != nil {
@@ -85,6 +133,35 @@ func (i *InitToken) EnsureDryRun() (bool, error) {
 	}
 
 	return false, result.ErrorOrNil()
+}
+
+func (i *InitToken) ensureDryRunInDate() (bool, error) {
+	token, err := i.InitToken()
+	if err != nil {
+		return true, err
+	}
+
+	s, err := i.kubernetes.vaultClient.Auth().Token().Lookup(token)
+	if err != nil {
+		if strings.Contains(err.Error(), "Code: 403.") &&
+			strings.Contains(err.Error(), "bad token") {
+			return true, nil
+		}
+
+		return true, err
+	}
+
+	ttl, err := s.TokenTTL()
+	if err != nil {
+		return true, err
+	}
+
+	// less than a year
+	if ttl.Hours() < 24*365 {
+		return true, nil
+	}
+
+	return false, nil
 }
 
 // Get init token name
@@ -181,13 +258,11 @@ func (i *InitToken) secretsBackend() *GenericVaultBackend {
 }
 
 func (i *InitToken) writeData() map[string]interface{} {
-	policies := i.Policies
-	//policies = append(policies, "default")
-
 	return map[string]interface{}{
-		"period":           fmt.Sprintf("%d", int(i.kubernetes.MaxValidityComponents.Seconds())),
+		"period":           fmt.Sprintf("%d", int(i.kubernetes.MaxValidityInitTokens.Seconds())),
 		"orphan":           true,
-		"allowed_policies": policies,
+		"allowed_policies": i.Policies,
 		"path_suffix":      i.namePath(),
+		"ttl":              fmt.Sprintf("%d", int(i.kubernetes.MaxValidityInitTokens.Seconds())),
 	}
 }

--- a/pkg/kubernetes/init_token.go
+++ b/pkg/kubernetes/init_token.go
@@ -101,9 +101,9 @@ func (i *InitToken) Delete() error {
 func (i *InitToken) EnsureDryRun() (bool, error) {
 	var result *multierror.Error
 
-	inDate, err := i.ensureDryRunInDate()
-	if err != nil || !inDate {
-		return inDate, err
+	expDate, err := i.ensureDryRunExpDate()
+	if err != nil || expDate {
+		return expDate, err
 	}
 
 	secret, err := i.readTokenRole()
@@ -135,7 +135,7 @@ func (i *InitToken) EnsureDryRun() (bool, error) {
 	return false, result.ErrorOrNil()
 }
 
-func (i *InitToken) ensureDryRunInDate() (bool, error) {
+func (i *InitToken) ensureDryRunExpDate() (bool, error) {
 	token, err := i.InitToken()
 	if err != nil {
 		return true, err
@@ -263,6 +263,5 @@ func (i *InitToken) writeData() map[string]interface{} {
 		"orphan":           true,
 		"allowed_policies": i.Policies,
 		"path_suffix":      i.namePath(),
-		"ttl":              fmt.Sprintf("%d", int(i.kubernetes.MaxValidityInitTokens.Seconds())),
 	}
 }

--- a/pkg/kubernetes/init_token_test.go
+++ b/pkg/kubernetes/init_token_test.go
@@ -64,6 +64,16 @@ func TestInitToken_Ensure_NoExpectedToken_NotExisting(t *testing.T) {
 		nil,
 	)
 
+	fv.fakeToken.EXPECT().Lookup("my-new-random-token").Return(
+		nil,
+		nil,
+	)
+
+	fv.fakeToken.EXPECT().Renew("my-new-random-token", 0).Return(
+		nil,
+		nil,
+	)
+
 	InitTokenEnsure_EXPECTs(fv)
 
 	err := i.Ensure()
@@ -106,6 +116,16 @@ func TestInitToken_Ensure_NoExpectedToken_AlreadyExisting(t *testing.T) {
 		nil,
 	)
 
+	fv.fakeToken.EXPECT().Lookup("existing-token").Return(
+		nil,
+		nil,
+	)
+
+	fv.fakeToken.EXPECT().Renew("existing-token", 0).Return(
+		nil,
+		nil,
+	)
+
 	InitTokenEnsure_EXPECTs(fv)
 
 	err := i.Ensure()
@@ -145,6 +165,16 @@ func TestInitToken_Ensure_ExpectedToken_Existing_Match(t *testing.T) {
 		&vault.Secret{
 			Data: map[string]interface{}{"init_token": "expected-token"},
 		},
+		nil,
+	)
+
+	fv.fakeToken.EXPECT().Lookup("expected-token").Return(
+		nil,
+		nil,
+	)
+
+	fv.fakeToken.EXPECT().Renew("expected-token", 0).Return(
+		nil,
 		nil,
 	)
 
@@ -207,6 +237,16 @@ func TestInitToken_Ensure_ExpectedToken_NotExisting(t *testing.T) {
 			},
 			nil,
 		),
+	)
+
+	fv.fakeToken.EXPECT().Lookup("expected-token").Return(
+		nil,
+		nil,
+	)
+
+	fv.fakeToken.EXPECT().Renew("expected-token", 0).Return(
+		nil,
+		nil,
 	)
 
 	InitTokenEnsure_EXPECTs(fv)

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -515,6 +515,7 @@ func (k *Kubernetes) ensureMaxLeaseTTL() error {
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
 

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -2,9 +2,11 @@
 package kubernetes
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"time"
 	"unicode"
@@ -62,6 +64,7 @@ type VaultToken interface {
 	CreateOrphan(opts *vault.TokenCreateRequest) (*vault.Secret, error)
 	RevokeOrphan(token string) error
 	Lookup(token string) (*vault.Secret, error)
+	Renew(token string, increment int) (*vault.Secret, error)
 }
 
 type Vault interface {
@@ -220,6 +223,10 @@ func (k *Kubernetes) Ensure() error {
 		return fmt.Errorf("error '%s' is not a valid clusterID", k.clusterID)
 	}
 
+	if err := k.ensureMaxLeaseTTL(); err != nil {
+		return err
+	}
+
 	// setup backends
 	var result *multierror.Error
 	for _, backend := range k.backends() {
@@ -278,6 +285,10 @@ func (k *Kubernetes) EnsureDryRun() (bool, error) {
 
 	if len(k.initTokens) == 0 {
 		k.initTokens = k.NewInitTokens()
+	}
+
+	if d.changeNeeded(k.ensureDryRunMaxLeaseTTL()) {
+		return true, d.ErrorOrNil()
 	}
 
 	for _, b := range k.backends() {
@@ -449,6 +460,76 @@ func (k *Kubernetes) InitTokens() map[string]string {
 		}
 	}
 	return output
+}
+
+func (k *Kubernetes) ensureDryRunMaxLeaseTTL() (bool, error) {
+	s, err := k.vaultClient.Logical().Read("/sys/auth")
+	if err != nil {
+		return true, err
+	}
+
+	token, err := mapFromData("token/", s.Data)
+	if err != nil {
+		return true, fmt.Errorf("failed to get token data at /sys/auth: %s", err)
+	}
+
+	config, err := mapFromData("config", token)
+	if err != nil {
+		return true, fmt.Errorf("failed to get config data at /sys/auth: %s", err)
+	}
+
+	ttl, ok := config["max_lease_ttl"]
+	if !ok {
+		return true, errors.New("failed to get max_lease_ttl from /sys/auth")
+	}
+
+	ttlN, ok := ttl.(json.Number)
+	if !ok {
+		fmt.Println()
+		return true, fmt.Errorf("unexpected max_lease_ttl type: %v", reflect.TypeOf(ttl))
+	}
+
+	ttlF, err := ttlN.Float64()
+	if err != nil {
+		return true, fmt.Errorf("failed to get float64 from json number: %s", err)
+	}
+
+	if ttlF != k.MaxValidityInitTokens.Seconds() {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func (k *Kubernetes) ensureMaxLeaseTTL() error {
+	b, err := k.ensureDryRunMaxLeaseTTL()
+	if err != nil || !b {
+		return err
+	}
+
+	k.Log.Infof("Tuning MaxLeaseTTL for mount /auth/token")
+
+	err = k.vaultClient.Sys().TuneMount("/auth/token", vault.MountConfigInput{
+		MaxLeaseTTL: fmt.Sprintf("%0.fs", k.MaxValidityInitTokens.Seconds()),
+	})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func mapFromData(key string, data map[string]interface{}) (map[string]interface{}, error) {
+	d, ok := data[key]
+	if !ok {
+		return nil, fmt.Errorf("failed to get %s key in map data", key)
+	}
+
+	dm, ok := d.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("returned key %s not map[string]string", key)
+	}
+
+	return dm, nil
 }
 
 func (k *Kubernetes) SetInitFlags(flags FlagInitTokens) {

--- a/pkg/kubernetes/kubernetes_test.go
+++ b/pkg/kubernetes/kubernetes_test.go
@@ -21,7 +21,7 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	v, err := vault_dev.InitVaultDev()
+	v, err := vault_dev.InitVaultDev("../../bin/vault")
 	if err != nil {
 		logrus.Fatalf("failed to initiate vault for testing: %v", err)
 	}

--- a/pkg/kubernetes/kubernetes_test.go
+++ b/pkg/kubernetes/kubernetes_test.go
@@ -3,6 +3,7 @@ package kubernetes
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -21,7 +22,12 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	v, err := vault_dev.InitVaultDev("../../bin/vault")
+	binPath, err := filepath.Abs("../../bin/vault")
+	if err != nil {
+		logrus.Fatal(err)
+	}
+
+	v, err := vault_dev.InitVaultDev(binPath)
 	if err != nil {
 		logrus.Fatalf("failed to initiate vault for testing: %v", err)
 	}

--- a/pkg/kubernetes/pki_vault_backend.go
+++ b/pkg/kubernetes/pki_vault_backend.go
@@ -153,8 +153,8 @@ func (p *PKIVaultBackend) generateCA() error {
 	description := "Kubernetes " + p.kubernetes.clusterID + "/" + p.pkiName + " CA"
 
 	data := map[string]interface{}{
-		"common_name": description,
-		"ttl":         p.getMaxLeaseTTL(),
+		"common_name":          description,
+		"ttl":                  p.getMaxLeaseTTL(),
 		"exclude_cn_from_sans": true,
 	}
 

--- a/pkg/testing/api/api_test.go
+++ b/pkg/testing/api/api_test.go
@@ -4,6 +4,7 @@ package api
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 
 	vault "github.com/hashicorp/vault/api"
@@ -23,11 +24,15 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	vaultDev, err := vault_dev.InitVaultDev("../../../bin/vault")
+	binPath, err := filepath.Abs("../../../bin/vault")
+	if err != nil {
+		logrus.Fatal(err)
+	}
+
+	v, err = vault_dev.InitVaultDev(binPath)
 	if err != nil {
 		logrus.Fatalf("failed to initiate vault for testing: %v", err)
 	}
-	v = vaultDev
 	defer v.Stop()
 	logrus.RegisterExitHandler(v.Stop)
 

--- a/pkg/testing/api/api_test.go
+++ b/pkg/testing/api/api_test.go
@@ -62,18 +62,20 @@ func checkDryRun(exp bool, t *testing.T) {
 	b, err := k.EnsureDryRun()
 	Must(err, t)
 	if b != exp {
-		t.Errorf("unexpected changes required, exp=%t got=%t", exp, b)
+		//t.Errorf("unexpected changes required, exp=%t got=%t", exp, b)
+		t.Fatalf("unexpected changes required, exp=%t got=%t", exp, b)
 	}
 }
 
 func createErrorData(dataMap map[string]interface{}) map[string]interface{} {
 	for key, data := range map[string]interface{}{
-		"max_ttl":         "0s",
-		"ttl":             "0s",
-		"organization":    "foo",
-		"allowed_domains": []string{"foo"},
-		"period":          "100s",
-		"orphan":          "false",
+		"max_ttl":          "0s",
+		"ttl":              "0s",
+		"organization":     "foo",
+		"allowed_domains":  []string{"foo"},
+		"period":           "100s",
+		"orphan":           "false",
+		"allowed_policies": []string{"foo"},
 	} {
 		dataMap[key] = data
 	}

--- a/pkg/testing/api/api_test.go
+++ b/pkg/testing/api/api_test.go
@@ -23,7 +23,7 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	vaultDev, err := vault_dev.InitVaultDev()
+	vaultDev, err := vault_dev.InitVaultDev("../../../bin/vault")
 	if err != nil {
 		logrus.Fatalf("failed to initiate vault for testing: %v", err)
 	}

--- a/pkg/testing/cli/cli_test.go
+++ b/pkg/testing/cli/cli_test.go
@@ -21,7 +21,7 @@ const (
 var tmpDirs []string
 
 func TestMain(m *testing.M) {
-	vault, err := vault_dev.InitVaultDev()
+	vault, err := vault_dev.InitVaultDev("../../../bin/vault")
 	if err != nil {
 		logrus.Fatalf("failed to initiate vault for testing: %v", err)
 	}

--- a/pkg/testing/vault_dev/vault_dev.go
+++ b/pkg/testing/vault_dev/vault_dev.go
@@ -27,7 +27,7 @@ func New() *VaultDev {
 	return &VaultDev{}
 }
 
-func (v *VaultDev) Start() error {
+func (v *VaultDev) Start(binPath string) error {
 
 	if v.port == nil {
 		p := getUnusedPort()
@@ -43,9 +43,16 @@ func (v *VaultDev) Start() error {
 
 	logrus.Infof("starting vault: %#+v", args)
 
-	v.server = exec.Command(v.binPath(), args...)
+	wd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
 
-	err := v.server.Start()
+	binPath = path.Join(wd, binPath)
+
+	v.server = exec.Command(binPath, args...)
+
+	err = v.server.Start()
 	if err != nil {
 		return err
 	}
@@ -128,10 +135,10 @@ func getUnusedPort() int {
 	return l.Addr().(*net.TCPAddr).Port
 }
 
-func InitVaultDev() (*VaultDev, error) {
+func InitVaultDev(binPath string) (*VaultDev, error) {
 	vaultDev := New()
 
-	if err := vaultDev.Start(); err != nil {
+	if err := vaultDev.Start(binPath); err != nil {
 		return nil, fmt.Errorf("unable to initialise vault dev server for testing: %v", err)
 	}
 
@@ -148,9 +155,4 @@ func InitVaultDev() (*VaultDev, error) {
 	}
 
 	return vaultDev, nil
-}
-
-func (v *VaultDev) binPath() string {
-	gp := os.Getenv("GOPATH")
-	return path.Join(gp, "src/github.com/jetstack/vault-helper/bin/vault")
 }

--- a/pkg/testing/vault_dev/vault_dev.go
+++ b/pkg/testing/vault_dev/vault_dev.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"path"
 	"syscall"
 	"time"
 
@@ -42,7 +43,7 @@ func (v *VaultDev) Start() error {
 
 	logrus.Infof("starting vault: %#+v", args)
 
-	v.server = exec.Command("vault", args...)
+	v.server = exec.Command(v.binPath(), args...)
 
 	err := v.server.Start()
 	if err != nil {
@@ -147,4 +148,9 @@ func InitVaultDev() (*VaultDev, error) {
 	}
 
 	return vaultDev, nil
+}
+
+func (v *VaultDev) binPath() string {
+	gp := os.Getenv("GOPATH")
+	return path.Join(gp, "src/github.com/jetstack/vault-helper/bin/vault")
 }

--- a/pkg/testing/vault_dev/vault_dev.go
+++ b/pkg/testing/vault_dev/vault_dev.go
@@ -6,7 +6,6 @@ import (
 	"net"
 	"os"
 	"os/exec"
-	"path"
 	"syscall"
 	"time"
 
@@ -43,16 +42,9 @@ func (v *VaultDev) Start(binPath string) error {
 
 	logrus.Infof("starting vault: %#+v", args)
 
-	wd, err := os.Getwd()
-	if err != nil {
-		return err
-	}
-
-	binPath = path.Join(wd, binPath)
-
 	v.server = exec.Command(binPath, args...)
 
-	err = v.server.Start()
+	err := v.server.Start()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Ensures init tokens have high ttl (5 years).
They are renewed.
They are recovered when they expire.

/assign @simonswine 

```release-note
Ensure init-tokens are longer lived (5 years) and recovered if expired
```
